### PR TITLE
BE 1.19.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <dependencies>
     <dependency>
       <groupId>com.github.CloudburstMC.Protocol</groupId>
-      <artifactId>bedrock-v544</artifactId>
-      <version>0bd459f</version>
+      <artifactId>bedrock-v554</artifactId>
+      <version>2.9.12-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.github.CloudburstMC.Protocol</groupId>
+      <groupId>com.nukkitx.protocol</groupId>
       <artifactId>bedrock-v554</artifactId>
       <version>2.9.12-SNAPSHOT</version>
       <scope>compile</scope>

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -40,6 +40,7 @@ import com.nukkitx.protocol.bedrock.v503.Bedrock_v503;
 import com.nukkitx.protocol.bedrock.v527.Bedrock_v527;
 import com.nukkitx.protocol.bedrock.v534.Bedrock_v534;
 import com.nukkitx.protocol.bedrock.v544.Bedrock_v544;
+import com.nukkitx.protocol.bedrock.v554.Bedrock_v554;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,11 +53,7 @@ public class BedrockVersionUtils {
      * Default Bedrock codec that should act as a fallback. Should represent the latest available
      * release of the game that Geyser supports.
      */
-    public static final BedrockPacketCodec LATEST_CODEC =
-            Bedrock_v544.V544_CODEC.toBuilder()
-                    .minecraftVersion("1.19.21")
-                    .protocolVersion(545)
-                    .build();
+    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v554.V554_CODEC;
     /**
      * A list of all supported Bedrock versions that can join Geyser
      */
@@ -77,6 +74,10 @@ public class BedrockVersionUtils {
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v527.V527_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v534.V534_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v544.V544_CODEC);
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v544.V544_CODEC.toBuilder()
+                .minecraftVersion("1.19.21")
+                .protocolVersion(545)
+                .build());
         SUPPORTED_BEDROCK_CODECS.add(LATEST_CODEC);
     }
 


### PR DESCRIPTION
RequestNetworkSettingsPacket is sent before the LoginPacket, for protocol 554. Also moved off of jitpack for Protocol.

Tested on 1.19.30/1.19.22/1.16.221