### PR TITLE
Support for BE 1.19.40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
   <dependencies>
     <dependency>
       <groupId>com.nukkitx.protocol</groupId>
-      <artifactId>bedrock-v554</artifactId>
-      <version>2.9.12-SNAPSHOT</version>
+      <artifactId>bedrock-v557</artifactId>
+      <version>2.9.13-SNAPSHOT</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -41,6 +41,7 @@ import com.nukkitx.protocol.bedrock.v527.Bedrock_v527;
 import com.nukkitx.protocol.bedrock.v534.Bedrock_v534;
 import com.nukkitx.protocol.bedrock.v544.Bedrock_v544;
 import com.nukkitx.protocol.bedrock.v554.Bedrock_v554;
+import com.nukkitx.protocol.bedrock.v557.Bedrock_v557;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,7 +54,7 @@ public class BedrockVersionUtils {
      * Default Bedrock codec that should act as a fallback. Should represent the latest available
      * release of the game that Geyser supports.
      */
-    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v554.V554_CODEC;
+    public static final BedrockPacketCodec LATEST_CODEC = Bedrock_v557.V557_CODEC;
     /**
      * A list of all supported Bedrock versions that can join Geyser
      */
@@ -78,6 +79,7 @@ public class BedrockVersionUtils {
                 .minecraftVersion("1.19.21")
                 .protocolVersion(545)
                 .build());
+        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v554.V554_CODEC);
         SUPPORTED_BEDROCK_CODECS.add(LATEST_CODEC);
     }
 


### PR DESCRIPTION
Tested on 1.19.31.1 and 1.19.40.24