### PR TITLE
Allow protocol to provide newer netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,14 +18,8 @@
     <dependency>
       <groupId>com.nukkitx.protocol</groupId>
       <artifactId>bedrock-v557</artifactId>
-      <version>2.9.13-SNAPSHOT</version>
+      <version>2.9.14-SNAPSHOT</version>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.nukkitx.fastutil</groupId>
@@ -37,6 +31,12 @@
       <artifactId>MCProtocolLib</artifactId>
       <version>5bea683</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.kyori</groupId>


### PR DESCRIPTION
cloudburst-network bumped netty dependency to 4.1.85 in order to add IP_DONTFRAG option.