### PR TITLE
Drop pre-1.20

### DIFF
--- a/src/main/java/org/geysermc/globallinkserver/bedrock/BedrockPlayer.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/BedrockPlayer.java
@@ -32,7 +32,6 @@ import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
 import org.cloudburstmc.protocol.bedrock.data.*;
-import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -142,11 +141,6 @@ public class BedrockPlayer implements Player {
         startGamePacket.setServerAuthoritativeBlockBreaking(false);
 
         session.sendPacket(startGamePacket);
-
-        // required for 1.16.100 - 1.16.201 (419 and 422)
-        CreativeContentPacket creativeContentPacket = new CreativeContentPacket();
-        creativeContentPacket.setContents(new ItemData[0]);
-        session.sendPacket(creativeContentPacket);
 
         // Send an empty chunk
         LevelChunkPacket data = new LevelChunkPacket();

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/PacketHandler.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/PacketHandler.java
@@ -115,7 +115,11 @@ public class PacketHandler implements BedrockPacketHandler {
     public PacketSignal handle(LoginPacket packet) {
         if (!networkSettingsRequested) {
             // This is expected for pre-1.19.30
-            session.disconnect("yeet");
+            PlayStatusPacket statusPacket = new PlayStatusPacket();
+            statusPacket.setStatus(PlayStatusPacket.Status.LOGIN_FAILED_CLIENT_OLD);
+            session.sendPacketImmediately(statusPacket);
+
+            session.disconnect();
             return PacketSignal.HANDLED;
         }
 

--- a/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
+++ b/src/main/java/org/geysermc/globallinkserver/bedrock/util/BedrockVersionUtils.java
@@ -26,28 +26,6 @@
 package org.geysermc.globallinkserver.bedrock.util;
 
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodec;
-import org.cloudburstmc.protocol.bedrock.codec.v419.Bedrock_v419;
-import org.cloudburstmc.protocol.bedrock.codec.v422.Bedrock_v422;
-import org.cloudburstmc.protocol.bedrock.codec.v428.Bedrock_v428;
-import org.cloudburstmc.protocol.bedrock.codec.v431.Bedrock_v431;
-import org.cloudburstmc.protocol.bedrock.codec.v440.Bedrock_v440;
-import org.cloudburstmc.protocol.bedrock.codec.v448.Bedrock_v448;
-import org.cloudburstmc.protocol.bedrock.codec.v465.Bedrock_v465;
-import org.cloudburstmc.protocol.bedrock.codec.v471.Bedrock_v471;
-import org.cloudburstmc.protocol.bedrock.codec.v475.Bedrock_v475;
-import org.cloudburstmc.protocol.bedrock.codec.v486.Bedrock_v486;
-import org.cloudburstmc.protocol.bedrock.codec.v503.Bedrock_v503;
-import org.cloudburstmc.protocol.bedrock.codec.v527.Bedrock_v527;
-import org.cloudburstmc.protocol.bedrock.codec.v534.Bedrock_v534;
-import org.cloudburstmc.protocol.bedrock.codec.v544.Bedrock_v544;
-import org.cloudburstmc.protocol.bedrock.codec.v545.Bedrock_v545;
-import org.cloudburstmc.protocol.bedrock.codec.v554.Bedrock_v554;
-import org.cloudburstmc.protocol.bedrock.codec.v557.Bedrock_v557;
-import org.cloudburstmc.protocol.bedrock.codec.v560.Bedrock_v560;
-import org.cloudburstmc.protocol.bedrock.codec.v567.Bedrock_v567;
-import org.cloudburstmc.protocol.bedrock.codec.v568.Bedrock_v568;
-import org.cloudburstmc.protocol.bedrock.codec.v575.Bedrock_v575;
-import org.cloudburstmc.protocol.bedrock.codec.v582.Bedrock_v582;
 import org.cloudburstmc.protocol.bedrock.codec.v589.Bedrock_v589;
 import org.cloudburstmc.protocol.bedrock.codec.v594.Bedrock_v594;
 
@@ -69,28 +47,6 @@ public class BedrockVersionUtils {
     public static final List<BedrockCodec> SUPPORTED_BEDROCK_CODECS = new ArrayList<>();
 
     static {
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v419.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v422.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v428.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v431.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v440.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v448.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v465.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v471.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v475.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v486.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v503.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v527.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v534.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v544.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v545.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v554.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v557.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v560.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v567.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v568.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v575.CODEC);
-        SUPPORTED_BEDROCK_CODECS.add(Bedrock_v582.CODEC);
         SUPPORTED_BEDROCK_CODECS.add(Bedrock_v589.CODEC);
         SUPPORTED_BEDROCK_CODECS.add(LATEST_CODEC);
     }


### PR DESCRIPTION
just for commit history: due to the key for XBL login JWTs being changed, it is not longer possible to authentice pre-1.20 clients with xbox live